### PR TITLE
Add presign command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,9 @@ Commands supported by qsctl are listed below:
   * - sync
     - Sync between local directory and QingStor prefix.
 
+  * - presign
+    - Generate a pre-signed URL for an object.
+
 --------
 Examples
 --------

--- a/docs/cn/source/reference/qsctl-presign.rst
+++ b/docs/cn/source/reference/qsctl-presign.rst
@@ -1,0 +1,46 @@
+.. _qsctl-presign:
+
+
+************************
+qsctl-presign
+************************
+
+
+====
+总览
+====
+
+::
+
+      qsctl presign
+    <qs-path>
+    [-e, --expire]
+
+====
+描述
+====
+
+生成 QingStor 对象的参数签名链接。在请求过期时间前，可以使用该链接下载 QingStor 对象。
+
+====
+选项
+====
+
+``-e, --expire``
+
+参数签名链接的过期时间，以秒为单位。默认为 3600 秒。
+
+====
+示例
+====
+
+下面的 ``presign`` 命令生成了 ``mybucket/myobject`` 对象的参数签名链接::
+
+    $ qsctl presign qs://mybucket/myobject
+
+输出::
+
+    https://pek3a.qingstor.com:443/mybucket/myobject?
+    signature=Miy/lgcPTU%2BtzBSnO4nJAdHsEh%2BEo6phvRZc1urckdE%3D
+    &access_key_id=EYGSPEMLUGZFBKORUSYO&expires=1488276950
+

--- a/docs/cn/source/reference/qsctl.rst
+++ b/docs/cn/source/reference/qsctl.rst
@@ -119,3 +119,4 @@ qsctl的通配符操作利用Exclude和Include过滤器实现。它和Unix操作
 * ``rb``
 * ``rm``
 * ``sync``
+* ``presign``

--- a/qingstor/qsctl/commands/presign.py
+++ b/qingstor/qsctl/commands/presign.py
@@ -1,0 +1,64 @@
+# -*- coding: UTF-8 -*-
+# =========================================================================
+# Copyright (C) 2017 Yunify, Inc.
+# -------------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this work except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file, or at:
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========================================================================
+
+from __future__ import unicode_literals
+
+import sys
+
+from .base import BaseCommand
+from ..utils import get_current_time
+
+
+class PresignCommand(BaseCommand):
+
+    command = "presign"
+    usage = "%(prog)s <qs-path> [-e <expire_seconds>]"
+
+    @classmethod
+    def add_extra_arguments(cls, parser):
+
+        parser.add_argument(
+            "qs_path", nargs="?", default="qs://", help="The qs-path to presign"
+        )
+
+        parser.add_argument(
+            "-e",
+            "--expire",
+            dest="expire_seconds",
+            type=int,
+            default=3600,
+            help="The number of seconds until the pre-signed URL expires."
+        )
+        return parser
+
+    @classmethod
+    def generate_presign_url(cls, options):
+        bucket, prefix = cls.validate_qs_path(options.qs_path)
+        if prefix == "":
+            print ("Error: please specify object in qs-path")
+            sys.exit(-1)
+        cls.validate_bucket(bucket)
+        current_bucket = cls.client.Bucket(bucket, cls.bucket_map[bucket])
+        prepared = current_bucket.get_object_request(prefix).sign_query(
+            get_current_time() + options.expire_seconds
+        )
+        print (prepared.url)
+        return prepared.url
+
+    @classmethod
+    def send_request(cls, options):
+        cls.generate_presign_url(options)

--- a/qingstor/qsctl/driver.py
+++ b/qingstor/qsctl/driver.py
@@ -31,8 +31,9 @@ from qingstor.qsctl.commands.rb import RbCommand
 from qingstor.qsctl.commands.mb import MbCommand
 from qingstor.qsctl.commands.mv import MvCommand
 from qingstor.qsctl.commands.sync import SyncCommand
+from qingstor.qsctl.commands.presign import PresignCommand
 
-COMMANDS = ('ls', 'cp', 'mb', 'mv', 'rb', 'rm', 'sync')
+COMMANDS = ('ls', 'cp', 'mb', 'mv', 'rb', 'rm', 'sync', 'presign')
 
 INDENT = ' ' * 2
 NEWLINE = '\n' + INDENT

--- a/qingstor/qsctl/helper/source/qsctl-presign.rst
+++ b/qingstor/qsctl/helper/source/qsctl-presign.rst
@@ -1,0 +1,47 @@
+.. _qsctl-presign:
+
+
+************************
+qsctl-presign
+************************
+
+
+========
+Synopsis
+========
+
+::
+
+      qsctl presign
+    <qs-path>
+    [-e, --expire]
+
+===========
+Description
+===========
+
+Generate a pre-signed URL for an object. Within the given expire time,
+anyone who receives this URL can retrieve the object with an HTTP GET request.
+
+=======
+Options
+=======
+
+``-e, --expire``
+
+The number of seconds until the pre-signed URL expires. Default is 3600 seconds.
+
+========
+Examples
+========
+
+The following ``presign`` command presigns object ``mybucket/myobject``::
+
+    $ qsctl presign qs://mybucket/myobject
+
+Output::
+
+    https://pek3a.qingstor.com:443/mybucket/myobject?
+    signature=Miy/lgcPTU%2BtzBSnO4nJAdHsEh%2BEo6phvRZc1urckdE%3D
+    &access_key_id=EYGSPEMLUGZFBKORUSYO&expires=1488276950
+

--- a/qingstor/qsctl/utils.py
+++ b/qingstor/qsctl/utils.py
@@ -21,6 +21,8 @@ import re
 import os
 import sys
 import json
+import time
+import calendar
 import platform
 from yaml import load
 
@@ -324,3 +326,7 @@ def validate_bucket_name(bucket_name):
         return False
 
     return True
+
+
+def get_current_time():
+    return calendar.timegm(time.gmtime())


### PR DESCRIPTION
Command presign generates a pre-signed URL for an object. Within the
given expire time, anyone who receives this URL can retrieve the object
with an HTTP GET request.