### PR TITLE
Fix problem that "rm -r" don't terminate

### DIFF
--- a/qingstor/qsctl/commands/ls.py
+++ b/qingstor/qsctl/commands/ls.py
@@ -113,7 +113,7 @@ class LsCommand(BaseCommand):
                 prefix, delimiter, marker, limit
             )
             cls.print_to_console(keys, dirs)
-            if marker == "":
+            if len(keys) + len(dirs) == 0:
                 break
 
     @classmethod


### PR DESCRIPTION
Determining next_marker empty is not reliable, that behavior has changed
recently.