### PR TITLE
cmd/cp: Add support for cp -r from root path.

### DIFF
--- a/cmd/qsctl/cp.go
+++ b/cmd/qsctl/cp.go
@@ -107,6 +107,11 @@ func HandleCpStorageBaseAndPath(t *taskutils.BetweenStorageTask) error {
 	}
 	t.SetSourcePath(filepath.Base(srcPath))
 
+	// if source path == source work dir，which means cp from '/', transfer to cp /*
+	if filepath.Base(srcPath) == filepath.Dir(srcPath) {
+		t.SetSourcePath("")
+	}
+
 	// Destination path depends on different condition.
 	dstPath, err := filepath.Abs(t.GetDestinationPath())
 	if err != nil {


### PR DESCRIPTION
Transfer `qsctl cp <root-path> <dst-path> -r` equal to `qsctl cp <root-path>/* <dst-path> -r`, make it work.